### PR TITLE
Add auto-upgrade support

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
   },
   "dependencies": {
     "@aws-sdk/client-ec2": "3.208.0",
+    "@aws-sdk/client-ecs": "^3.213.0",
+    "date-fns": "^2.29.3",
     "dotenv": "^16.0.3",
     "fast-json-patch": "^3.1.1",
     "long": "4.x",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,8 +2,10 @@ lockfileVersion: 5.4
 
 specifiers:
   '@aws-sdk/client-ec2': 3.208.0
+  '@aws-sdk/client-ecs': ^3.213.0
   '@types/long': 4.x
   '@types/node': ~18.11.9
+  date-fns: ^2.29.3
   dotenv: ^16.0.3
   esbuild: ^0.15.13
   esbuild-node-externals: ^1.5.0
@@ -23,6 +25,8 @@ specifiers:
 
 dependencies:
   '@aws-sdk/client-ec2': 3.208.0
+  '@aws-sdk/client-ecs': 3.213.0
+  date-fns: 2.29.3
   dotenv: 16.0.3
   fast-json-patch: 3.1.1
   long: 4.0.0
@@ -59,7 +63,7 @@ packages:
       '@aws-crypto/sha256-js': 2.0.0
       '@aws-crypto/supports-web-crypto': 2.0.2
       '@aws-crypto/util': 2.0.2
-      '@aws-sdk/types': 3.208.0
+      '@aws-sdk/types': 3.212.0
       '@aws-sdk/util-locate-window': 3.208.0
       '@aws-sdk/util-utf8-browser': 3.188.0
       tslib: 1.14.1
@@ -69,7 +73,7 @@ packages:
     resolution: {integrity: sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==}
     dependencies:
       '@aws-crypto/util': 2.0.2
-      '@aws-sdk/types': 3.208.0
+      '@aws-sdk/types': 3.212.0
       tslib: 1.14.1
     dev: false
 
@@ -82,7 +86,7 @@ packages:
   /@aws-crypto/util/2.0.2:
     resolution: {integrity: sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==}
     dependencies:
-      '@aws-sdk/types': 3.208.0
+      '@aws-sdk/types': 3.212.0
       '@aws-sdk/util-utf8-browser': 3.188.0
       tslib: 1.14.1
     dev: false
@@ -92,6 +96,14 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-sdk/types': 3.208.0
+      tslib: 2.4.1
+    dev: false
+
+  /@aws-sdk/abort-controller/3.212.0:
+    resolution: {integrity: sha512-mXeBSuDi0Fpul4zk9VH2z0VKN+/+6hyJ9SXSRhn3LpMcyj3GeZtXyTB2wCsfxXYGxeGbV+bIzbPbhZza6wNfWg==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.212.0
       tslib: 2.4.1
     dev: false
 
@@ -144,6 +156,90 @@ packages:
       - aws-crt
     dev: false
 
+  /@aws-sdk/client-ecs/3.213.0:
+    resolution: {integrity: sha512-Vz4aprAAUTB4GFUMMXJH6hHmtNa93GDrc3oZfh0gGa1swWR6MHB12zqO9BJuNubL3xv7OoKARwnyYLMMEGZDXg==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-crypto/sha256-browser': 2.0.0
+      '@aws-crypto/sha256-js': 2.0.0
+      '@aws-sdk/client-sts': 3.213.0
+      '@aws-sdk/config-resolver': 3.212.0
+      '@aws-sdk/credential-provider-node': 3.212.0
+      '@aws-sdk/fetch-http-handler': 3.212.0
+      '@aws-sdk/hash-node': 3.212.0
+      '@aws-sdk/invalid-dependency': 3.212.0
+      '@aws-sdk/middleware-content-length': 3.212.0
+      '@aws-sdk/middleware-endpoint': 3.212.0
+      '@aws-sdk/middleware-host-header': 3.212.0
+      '@aws-sdk/middleware-logger': 3.212.0
+      '@aws-sdk/middleware-recursion-detection': 3.212.0
+      '@aws-sdk/middleware-retry': 3.212.0
+      '@aws-sdk/middleware-serde': 3.212.0
+      '@aws-sdk/middleware-signing': 3.212.0
+      '@aws-sdk/middleware-stack': 3.212.0
+      '@aws-sdk/middleware-user-agent': 3.212.0
+      '@aws-sdk/node-config-provider': 3.212.0
+      '@aws-sdk/node-http-handler': 3.212.0
+      '@aws-sdk/protocol-http': 3.212.0
+      '@aws-sdk/smithy-client': 3.212.0
+      '@aws-sdk/types': 3.212.0
+      '@aws-sdk/url-parser': 3.212.0
+      '@aws-sdk/util-base64': 3.208.0
+      '@aws-sdk/util-body-length-browser': 3.188.0
+      '@aws-sdk/util-body-length-node': 3.208.0
+      '@aws-sdk/util-defaults-mode-browser': 3.212.0
+      '@aws-sdk/util-defaults-mode-node': 3.212.0
+      '@aws-sdk/util-endpoints': 3.212.0
+      '@aws-sdk/util-user-agent-browser': 3.212.0
+      '@aws-sdk/util-user-agent-node': 3.212.0
+      '@aws-sdk/util-utf8-browser': 3.188.0
+      '@aws-sdk/util-utf8-node': 3.208.0
+      '@aws-sdk/util-waiter': 3.212.0
+      tslib: 2.4.1
+    transitivePeerDependencies:
+      - aws-crt
+    dev: false
+
+  /@aws-sdk/client-sso-oidc/3.212.0:
+    resolution: {integrity: sha512-Co0AU+y9KEAZUraT36ttFZlmwARsr82q2nQji5E8zg3zlUHtqGvMJqxArudz3iOb2E9WRi75MwAQmLO2xEk45A==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-crypto/sha256-browser': 2.0.0
+      '@aws-crypto/sha256-js': 2.0.0
+      '@aws-sdk/config-resolver': 3.212.0
+      '@aws-sdk/fetch-http-handler': 3.212.0
+      '@aws-sdk/hash-node': 3.212.0
+      '@aws-sdk/invalid-dependency': 3.212.0
+      '@aws-sdk/middleware-content-length': 3.212.0
+      '@aws-sdk/middleware-endpoint': 3.212.0
+      '@aws-sdk/middleware-host-header': 3.212.0
+      '@aws-sdk/middleware-logger': 3.212.0
+      '@aws-sdk/middleware-recursion-detection': 3.212.0
+      '@aws-sdk/middleware-retry': 3.212.0
+      '@aws-sdk/middleware-serde': 3.212.0
+      '@aws-sdk/middleware-stack': 3.212.0
+      '@aws-sdk/middleware-user-agent': 3.212.0
+      '@aws-sdk/node-config-provider': 3.212.0
+      '@aws-sdk/node-http-handler': 3.212.0
+      '@aws-sdk/protocol-http': 3.212.0
+      '@aws-sdk/smithy-client': 3.212.0
+      '@aws-sdk/types': 3.212.0
+      '@aws-sdk/url-parser': 3.212.0
+      '@aws-sdk/util-base64': 3.208.0
+      '@aws-sdk/util-body-length-browser': 3.188.0
+      '@aws-sdk/util-body-length-node': 3.208.0
+      '@aws-sdk/util-defaults-mode-browser': 3.212.0
+      '@aws-sdk/util-defaults-mode-node': 3.212.0
+      '@aws-sdk/util-endpoints': 3.212.0
+      '@aws-sdk/util-user-agent-browser': 3.212.0
+      '@aws-sdk/util-user-agent-node': 3.212.0
+      '@aws-sdk/util-utf8-browser': 3.188.0
+      '@aws-sdk/util-utf8-node': 3.208.0
+      tslib: 2.4.1
+    transitivePeerDependencies:
+      - aws-crt
+    dev: false
+
   /@aws-sdk/client-sso/3.208.0:
     resolution: {integrity: sha512-3e6kEFtuxqZVv1cLGbXFAytTPzR1GpctKITEtJR0MFy3pzj8ttbybrHe0F8z2AqAtDhna1i3u1WVZa+LK3gE9Q==}
     engines: {node: '>=14.0.0'}
@@ -179,6 +275,46 @@ packages:
       '@aws-sdk/util-endpoints': 3.208.0
       '@aws-sdk/util-user-agent-browser': 3.208.0
       '@aws-sdk/util-user-agent-node': 3.208.0
+      '@aws-sdk/util-utf8-browser': 3.188.0
+      '@aws-sdk/util-utf8-node': 3.208.0
+      tslib: 2.4.1
+    transitivePeerDependencies:
+      - aws-crt
+    dev: false
+
+  /@aws-sdk/client-sso/3.212.0:
+    resolution: {integrity: sha512-b9lFI8Uz6YxIzAlS2uq62y5fX097lwcdkiq2N8YN2U7YgHQaKMIFnV8ZqkDdhZi2eUKwhSdUZzQy0tF6en2Ubg==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-crypto/sha256-browser': 2.0.0
+      '@aws-crypto/sha256-js': 2.0.0
+      '@aws-sdk/config-resolver': 3.212.0
+      '@aws-sdk/fetch-http-handler': 3.212.0
+      '@aws-sdk/hash-node': 3.212.0
+      '@aws-sdk/invalid-dependency': 3.212.0
+      '@aws-sdk/middleware-content-length': 3.212.0
+      '@aws-sdk/middleware-endpoint': 3.212.0
+      '@aws-sdk/middleware-host-header': 3.212.0
+      '@aws-sdk/middleware-logger': 3.212.0
+      '@aws-sdk/middleware-recursion-detection': 3.212.0
+      '@aws-sdk/middleware-retry': 3.212.0
+      '@aws-sdk/middleware-serde': 3.212.0
+      '@aws-sdk/middleware-stack': 3.212.0
+      '@aws-sdk/middleware-user-agent': 3.212.0
+      '@aws-sdk/node-config-provider': 3.212.0
+      '@aws-sdk/node-http-handler': 3.212.0
+      '@aws-sdk/protocol-http': 3.212.0
+      '@aws-sdk/smithy-client': 3.212.0
+      '@aws-sdk/types': 3.212.0
+      '@aws-sdk/url-parser': 3.212.0
+      '@aws-sdk/util-base64': 3.208.0
+      '@aws-sdk/util-body-length-browser': 3.188.0
+      '@aws-sdk/util-body-length-node': 3.208.0
+      '@aws-sdk/util-defaults-mode-browser': 3.212.0
+      '@aws-sdk/util-defaults-mode-node': 3.212.0
+      '@aws-sdk/util-endpoints': 3.212.0
+      '@aws-sdk/util-user-agent-browser': 3.212.0
+      '@aws-sdk/util-user-agent-node': 3.212.0
       '@aws-sdk/util-utf8-browser': 3.188.0
       '@aws-sdk/util-utf8-node': 3.208.0
       tslib: 2.4.1
@@ -232,6 +368,50 @@ packages:
       - aws-crt
     dev: false
 
+  /@aws-sdk/client-sts/3.213.0:
+    resolution: {integrity: sha512-MCjtLaYVQJLIMeLubDc4yRjSyVVTOebKxhY4ix4cfpSA6X4jMc4gRY2eu4eja3qoISfHq/Ikrkxx9DD1+n1azg==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-crypto/sha256-browser': 2.0.0
+      '@aws-crypto/sha256-js': 2.0.0
+      '@aws-sdk/config-resolver': 3.212.0
+      '@aws-sdk/credential-provider-node': 3.212.0
+      '@aws-sdk/fetch-http-handler': 3.212.0
+      '@aws-sdk/hash-node': 3.212.0
+      '@aws-sdk/invalid-dependency': 3.212.0
+      '@aws-sdk/middleware-content-length': 3.212.0
+      '@aws-sdk/middleware-endpoint': 3.212.0
+      '@aws-sdk/middleware-host-header': 3.212.0
+      '@aws-sdk/middleware-logger': 3.212.0
+      '@aws-sdk/middleware-recursion-detection': 3.212.0
+      '@aws-sdk/middleware-retry': 3.212.0
+      '@aws-sdk/middleware-sdk-sts': 3.212.0
+      '@aws-sdk/middleware-serde': 3.212.0
+      '@aws-sdk/middleware-signing': 3.212.0
+      '@aws-sdk/middleware-stack': 3.212.0
+      '@aws-sdk/middleware-user-agent': 3.212.0
+      '@aws-sdk/node-config-provider': 3.212.0
+      '@aws-sdk/node-http-handler': 3.212.0
+      '@aws-sdk/protocol-http': 3.212.0
+      '@aws-sdk/smithy-client': 3.212.0
+      '@aws-sdk/types': 3.212.0
+      '@aws-sdk/url-parser': 3.212.0
+      '@aws-sdk/util-base64': 3.208.0
+      '@aws-sdk/util-body-length-browser': 3.188.0
+      '@aws-sdk/util-body-length-node': 3.208.0
+      '@aws-sdk/util-defaults-mode-browser': 3.212.0
+      '@aws-sdk/util-defaults-mode-node': 3.212.0
+      '@aws-sdk/util-endpoints': 3.212.0
+      '@aws-sdk/util-user-agent-browser': 3.212.0
+      '@aws-sdk/util-user-agent-node': 3.212.0
+      '@aws-sdk/util-utf8-browser': 3.188.0
+      '@aws-sdk/util-utf8-node': 3.208.0
+      fast-xml-parser: 4.0.11
+      tslib: 2.4.1
+    transitivePeerDependencies:
+      - aws-crt
+    dev: false
+
   /@aws-sdk/config-resolver/3.208.0:
     resolution: {integrity: sha512-eLwI7rjk3AJj/S8PqRcUi9iBD+cTm1Nzu1CmYyeiwU6YbJLe5/2CrhW1wjkOGleE+aD967U1TWiB18tsx6fj+w==}
     engines: {node: '>=14.0.0'}
@@ -243,12 +423,32 @@ packages:
       tslib: 2.4.1
     dev: false
 
+  /@aws-sdk/config-resolver/3.212.0:
+    resolution: {integrity: sha512-hIP/Izpv6GCsDTnHCd/X9Ro7Mw5le+gr2VbkZHWR0c8+3xZWp8N5S0QnUBogF3Dv2KwPbmHP+bs/vqqo3miUjQ==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/signature-v4': 3.212.0
+      '@aws-sdk/types': 3.212.0
+      '@aws-sdk/util-config-provider': 3.208.0
+      '@aws-sdk/util-middleware': 3.212.0
+      tslib: 2.4.1
+    dev: false
+
   /@aws-sdk/credential-provider-env/3.208.0:
     resolution: {integrity: sha512-FB+KUSpZc03wVTXxGnMmgtaP0sJOv0D7oyogHb7wcf5b7RjjwqoaeUcJHTdKRZaW6e1foLk3/L9uebxiWefDbQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-sdk/property-provider': 3.208.0
       '@aws-sdk/types': 3.208.0
+      tslib: 2.4.1
+    dev: false
+
+  /@aws-sdk/credential-provider-env/3.212.0:
+    resolution: {integrity: sha512-HNYoqetLqTxwl0Grl4ez8Dx3I3hJfskxH2PTHYI1/iAqrY/gSB2oBOusvBeksbYrScnQM2IGqEcMJ4lzGLOH+w==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/property-provider': 3.212.0
+      '@aws-sdk/types': 3.212.0
       tslib: 2.4.1
     dev: false
 
@@ -263,6 +463,17 @@ packages:
       tslib: 2.4.1
     dev: false
 
+  /@aws-sdk/credential-provider-imds/3.212.0:
+    resolution: {integrity: sha512-Bg7cX2N5pJ//ft3Y8HWtpDSEMMgRTNMaNlIvTlDbAKYp7HBZRWSf9ZJnz2slT7qbyaJyRP5pSJC4XRm83g4leA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/node-config-provider': 3.212.0
+      '@aws-sdk/property-provider': 3.212.0
+      '@aws-sdk/types': 3.212.0
+      '@aws-sdk/url-parser': 3.212.0
+      tslib: 2.4.1
+    dev: false
+
   /@aws-sdk/credential-provider-ini/3.208.0:
     resolution: {integrity: sha512-AhsUj4046wMnxrPunNVEuddOIb//KsaicRqucw1Pb/UqszDRO4hYWkw7pL10MPIqjHBwuXYZ3vjDZrIhIWMn7A==}
     engines: {node: '>=14.0.0'}
@@ -274,6 +485,22 @@ packages:
       '@aws-sdk/property-provider': 3.208.0
       '@aws-sdk/shared-ini-file-loader': 3.208.0
       '@aws-sdk/types': 3.208.0
+      tslib: 2.4.1
+    transitivePeerDependencies:
+      - aws-crt
+    dev: false
+
+  /@aws-sdk/credential-provider-ini/3.212.0:
+    resolution: {integrity: sha512-H7qRIP8qV7tRrCSJx2p5oQVMJASQWZUmi4l699hDMejmCO/m4pUMQFmWn2FXtZv8gTfzlkmp3wMixD5jnfL7pw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.212.0
+      '@aws-sdk/credential-provider-imds': 3.212.0
+      '@aws-sdk/credential-provider-sso': 3.212.0
+      '@aws-sdk/credential-provider-web-identity': 3.212.0
+      '@aws-sdk/property-provider': 3.212.0
+      '@aws-sdk/shared-ini-file-loader': 3.212.0
+      '@aws-sdk/types': 3.212.0
       tslib: 2.4.1
     transitivePeerDependencies:
       - aws-crt
@@ -297,6 +524,24 @@ packages:
       - aws-crt
     dev: false
 
+  /@aws-sdk/credential-provider-node/3.212.0:
+    resolution: {integrity: sha512-T44hoU3GCYHS+4GDVs7S/v2bBHmmYpnPayQsYXhDElQKXP0cFzQ78F8et4IU5lM94hwK+ISRQPrKaq4p77evkw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.212.0
+      '@aws-sdk/credential-provider-imds': 3.212.0
+      '@aws-sdk/credential-provider-ini': 3.212.0
+      '@aws-sdk/credential-provider-process': 3.212.0
+      '@aws-sdk/credential-provider-sso': 3.212.0
+      '@aws-sdk/credential-provider-web-identity': 3.212.0
+      '@aws-sdk/property-provider': 3.212.0
+      '@aws-sdk/shared-ini-file-loader': 3.212.0
+      '@aws-sdk/types': 3.212.0
+      tslib: 2.4.1
+    transitivePeerDependencies:
+      - aws-crt
+    dev: false
+
   /@aws-sdk/credential-provider-process/3.208.0:
     resolution: {integrity: sha512-ExvFSJB/pVV+/BXIvFR9dgoGxWWnF6uqIw1hfpWCh28UDwsOQdbfUKblMovUfPDBUw67Laqy3mtiY37Jyo/EUQ==}
     engines: {node: '>=14.0.0'}
@@ -304,6 +549,16 @@ packages:
       '@aws-sdk/property-provider': 3.208.0
       '@aws-sdk/shared-ini-file-loader': 3.208.0
       '@aws-sdk/types': 3.208.0
+      tslib: 2.4.1
+    dev: false
+
+  /@aws-sdk/credential-provider-process/3.212.0:
+    resolution: {integrity: sha512-bGaVKSm5Tf5VZtlM2V6k+M9nSKzlb14ldCcH0PGGMaK/dqnEJDVSxXPu3fWyomaxbLt7Is3AUMh6L2bq3kuXyA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/property-provider': 3.212.0
+      '@aws-sdk/shared-ini-file-loader': 3.212.0
+      '@aws-sdk/types': 3.212.0
       tslib: 2.4.1
     dev: false
 
@@ -320,12 +575,35 @@ packages:
       - aws-crt
     dev: false
 
+  /@aws-sdk/credential-provider-sso/3.212.0:
+    resolution: {integrity: sha512-OGatVUnWLp7PePs2H2RyYmTrwurl0tAfW+LWfVAPgYyvi2RQgTmSK5LJ3pXKxz3TvaSHkCvsT0NWNqdWY+iKWQ==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/client-sso': 3.212.0
+      '@aws-sdk/property-provider': 3.212.0
+      '@aws-sdk/shared-ini-file-loader': 3.212.0
+      '@aws-sdk/token-providers': 3.212.0
+      '@aws-sdk/types': 3.212.0
+      tslib: 2.4.1
+    transitivePeerDependencies:
+      - aws-crt
+    dev: false
+
   /@aws-sdk/credential-provider-web-identity/3.208.0:
     resolution: {integrity: sha512-7wtrdEr8uvDr5t0stimrXGsW4G+TQyluZ9OucCCY0HXgNihmnk1BIu+COuOSxRtFXHwCh4rIPaVE1ABG2Mq24g==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-sdk/property-provider': 3.208.0
       '@aws-sdk/types': 3.208.0
+      tslib: 2.4.1
+    dev: false
+
+  /@aws-sdk/credential-provider-web-identity/3.212.0:
+    resolution: {integrity: sha512-zPF3KiVT14aeu4cRyEUelAJEAzFp++9ULLigQXhKBbFYaiOZMAHKRASO/WUK1ixYBC+ax4G1rbihLfQimXMtVA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/property-provider': 3.212.0
+      '@aws-sdk/types': 3.212.0
       tslib: 2.4.1
     dev: false
 
@@ -339,6 +617,16 @@ packages:
       tslib: 2.4.1
     dev: false
 
+  /@aws-sdk/fetch-http-handler/3.212.0:
+    resolution: {integrity: sha512-u7ehnpAVN8D0asWhyQitNVf1j5LdzCuxP/14Dx8+PvrUdZxQNVq2FVB+tkQvOs9pDHE/oROjVo7GNO42bmkitA==}
+    dependencies:
+      '@aws-sdk/protocol-http': 3.212.0
+      '@aws-sdk/querystring-builder': 3.212.0
+      '@aws-sdk/types': 3.212.0
+      '@aws-sdk/util-base64': 3.208.0
+      tslib: 2.4.1
+    dev: false
+
   /@aws-sdk/hash-node/3.208.0:
     resolution: {integrity: sha512-X5u6nD9+wzaA6qhqbobxsIgiyDJMW8NgqjZgHoc5x1wz4unHUCEuSBZy1kbIZ6+EPZ9bQHQZ21gKgf1j5vhsvQ==}
     engines: {node: '>=14.0.0'}
@@ -348,10 +636,26 @@ packages:
       tslib: 2.4.1
     dev: false
 
+  /@aws-sdk/hash-node/3.212.0:
+    resolution: {integrity: sha512-pwZkz83EvXHGURBYjBYS7Cr+gSr6pi23RDlP/aXREjJGs9QUQyixBh78oX5a3p6bB8JeizPcZS1dXKJ9OKCHAw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.212.0
+      '@aws-sdk/util-buffer-from': 3.208.0
+      tslib: 2.4.1
+    dev: false
+
   /@aws-sdk/invalid-dependency/3.208.0:
     resolution: {integrity: sha512-mUpbtijk14KntYy+w5FSvmsfj/Dqa8HylYeCKniKBKkQ1avjEz7CdizVoxyZrR3rldnLE3gItr0FEDRUhtfkAA==}
     dependencies:
       '@aws-sdk/types': 3.208.0
+      tslib: 2.4.1
+    dev: false
+
+  /@aws-sdk/invalid-dependency/3.212.0:
+    resolution: {integrity: sha512-zKVx+4Silmsr5Nvv9aGL5FmuHvdP9Dcvy/22fmWa3RRvCSNRpvFDeXtcDB5FvNpbWbO+qJyGj/OeqB/XejV13w==}
+    dependencies:
+      '@aws-sdk/types': 3.212.0
       tslib: 2.4.1
     dev: false
 
@@ -371,6 +675,15 @@ packages:
       tslib: 2.4.1
     dev: false
 
+  /@aws-sdk/middleware-content-length/3.212.0:
+    resolution: {integrity: sha512-gR6jeKGYNYqNLFRcuX3vv5PN1POLlB/9LDVYl3k/NNaCg8L1EKqqEtG84Gmn1AXH+2s6zMNs+gt5ygeqZQe2Cw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/protocol-http': 3.212.0
+      '@aws-sdk/types': 3.212.0
+      tslib: 2.4.1
+    dev: false
+
   /@aws-sdk/middleware-endpoint/3.208.0:
     resolution: {integrity: sha512-pVa/cyB6ronfTVAoKUUTFbAPslDPU43DWOKXY/bACC3ys1lFo1CWjz4dLSQARxEEW3iZ1yZTy0zoHXnNrw5CFQ==}
     engines: {node: '>=14.0.0'}
@@ -385,6 +698,20 @@ packages:
       tslib: 2.4.1
     dev: false
 
+  /@aws-sdk/middleware-endpoint/3.212.0:
+    resolution: {integrity: sha512-6ntKYehjxLun8hPXIPHSI2pGr/pHuQ6jcyO5wBq1kydSIIGiESl8H84DEt+yRvroCiYgbU+I8cACnRE0uv0bLA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/middleware-serde': 3.212.0
+      '@aws-sdk/protocol-http': 3.212.0
+      '@aws-sdk/signature-v4': 3.212.0
+      '@aws-sdk/types': 3.212.0
+      '@aws-sdk/url-parser': 3.212.0
+      '@aws-sdk/util-config-provider': 3.208.0
+      '@aws-sdk/util-middleware': 3.212.0
+      tslib: 2.4.1
+    dev: false
+
   /@aws-sdk/middleware-host-header/3.208.0:
     resolution: {integrity: sha512-3oyXK81TLWOZ2T/9Ltpbj/Z7R4QWSf+FCQRpY48ND2im/ALkgFRk/tmDTOshv+TQzW1q2lOSEeq4vK6yOCar7g==}
     engines: {node: '>=14.0.0'}
@@ -394,11 +721,28 @@ packages:
       tslib: 2.4.1
     dev: false
 
+  /@aws-sdk/middleware-host-header/3.212.0:
+    resolution: {integrity: sha512-W00mxzK2OXy91Ncxri3cZJIxxSBzE72bX8FDa3xgC0ujbj49lw+rol6aV/Fw8Nda3CZ5xxulvJ4sXHt2eOtXSA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/protocol-http': 3.212.0
+      '@aws-sdk/types': 3.212.0
+      tslib: 2.4.1
+    dev: false
+
   /@aws-sdk/middleware-logger/3.208.0:
     resolution: {integrity: sha512-mwSpuWruB8RrgUAAW7w/lvadnMDesl/bZ2IELBgJri+2rIqLGbAtygJBiG0Y3e8/IeOHuKuGkN1rFYZ4SKr7/A==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-sdk/types': 3.208.0
+      tslib: 2.4.1
+    dev: false
+
+  /@aws-sdk/middleware-logger/3.212.0:
+    resolution: {integrity: sha512-BSQqzKp4abf2wXvJEstB0zdr68yJMZXA14h53eSvtzykZLfvvFixR1nyVgKq+PKm1VaJ2fuZr10tjWRVQg1pYA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.212.0
       tslib: 2.4.1
     dev: false
 
@@ -411,6 +755,15 @@ packages:
       tslib: 2.4.1
     dev: false
 
+  /@aws-sdk/middleware-recursion-detection/3.212.0:
+    resolution: {integrity: sha512-ATHPNtnd7nlm0jRXvr/c2xbxcna5ZGXEWTM5tUjIflOK9Rl3PCRce/hoQnHs45kv4l3daC53sPuRvTQ8O7K67A==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/protocol-http': 3.212.0
+      '@aws-sdk/types': 3.212.0
+      tslib: 2.4.1
+    dev: false
+
   /@aws-sdk/middleware-retry/3.208.0:
     resolution: {integrity: sha512-JAcN2e3PKWGcNX7run/jP6xJ7w2m15a2CpVrfMtka9p/I/3qnqB86jGUs/3Iv04FEqgXq7KTHbFBg8CndsaHEw==}
     engines: {node: '>=14.0.0'}
@@ -419,6 +772,18 @@ packages:
       '@aws-sdk/service-error-classification': 3.208.0
       '@aws-sdk/types': 3.208.0
       '@aws-sdk/util-middleware': 3.208.0
+      tslib: 2.4.1
+      uuid: 8.3.2
+    dev: false
+
+  /@aws-sdk/middleware-retry/3.212.0:
+    resolution: {integrity: sha512-lIi/JkYXalY6CYw2dJbQ/Xo64Ah3wfJ63BMTFQHQk1htnIDBnLd9a6ng96JgXJQMSO4ZEqRW/709NBlC157hbw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/protocol-http': 3.212.0
+      '@aws-sdk/service-error-classification': 3.212.0
+      '@aws-sdk/types': 3.212.0
+      '@aws-sdk/util-middleware': 3.212.0
       tslib: 2.4.1
       uuid: 8.3.2
     dev: false
@@ -447,11 +812,31 @@ packages:
       tslib: 2.4.1
     dev: false
 
+  /@aws-sdk/middleware-sdk-sts/3.212.0:
+    resolution: {integrity: sha512-IcMfno3RJEXXS1Ch5lY0hgdSkGn9XW9m3XoKu1DjhEqR34ENDzvUmEN2PimIcZnz+9W59CU9UAMs/amRhwhlmw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/middleware-signing': 3.212.0
+      '@aws-sdk/property-provider': 3.212.0
+      '@aws-sdk/protocol-http': 3.212.0
+      '@aws-sdk/signature-v4': 3.212.0
+      '@aws-sdk/types': 3.212.0
+      tslib: 2.4.1
+    dev: false
+
   /@aws-sdk/middleware-serde/3.208.0:
     resolution: {integrity: sha512-3h2yP6qyf/IhfdvyFeNX7w4BF37vOZvfUDBq+wb1QEc7DCAskoUKWtCCKJ9HDq3IJQp8hzqY82eawUir6flqlQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-sdk/types': 3.208.0
+      tslib: 2.4.1
+    dev: false
+
+  /@aws-sdk/middleware-serde/3.212.0:
+    resolution: {integrity: sha512-KwRpwi/8vNDV0l8uvu1DPk0q3WR2pnp9VtUNZ6u9zU54hvVL+Z1PtQh/WfzJzNvtCHvtc/gVMs3Daqb/Ecrm5Q==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.212.0
       tslib: 2.4.1
     dev: false
 
@@ -467,8 +852,27 @@ packages:
       tslib: 2.4.1
     dev: false
 
+  /@aws-sdk/middleware-signing/3.212.0:
+    resolution: {integrity: sha512-pth95aEsxqQO0lrRAHZNVI5hrMtA14nEUPFjiLaXtOssZrjD6mBzXPRy1nKob6XWXOp/Vy0mnyI/FT/NnMflFw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/property-provider': 3.212.0
+      '@aws-sdk/protocol-http': 3.212.0
+      '@aws-sdk/signature-v4': 3.212.0
+      '@aws-sdk/types': 3.212.0
+      '@aws-sdk/util-middleware': 3.212.0
+      tslib: 2.4.1
+    dev: false
+
   /@aws-sdk/middleware-stack/3.208.0:
     resolution: {integrity: sha512-bvFPUa+RTB7PSRCUsO6bRlEtiEadrDES+dpNmInMNQ9kmbd4OhNOCb664hhtiglIIXX5cd8mSPEo+w/RV0kEEQ==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      tslib: 2.4.1
+    dev: false
+
+  /@aws-sdk/middleware-stack/3.212.0:
+    resolution: {integrity: sha512-AZ5f9ChioHsxGUojlzqI57sYyM9oW9SN/7AuiNafXU02j9jw7DKiYRn43lRUhgYnb/REhedHA5SsqIBF5eut/w==}
     engines: {node: '>=14.0.0'}
     dependencies:
       tslib: 2.4.1
@@ -483,6 +887,15 @@ packages:
       tslib: 2.4.1
     dev: false
 
+  /@aws-sdk/middleware-user-agent/3.212.0:
+    resolution: {integrity: sha512-CVSY2kt+RaP6CVqSKp+1sPUAQFusTLZLFHVK0YPFzcIySJMqJC0l0/BzLhaIf5Bs3JHa/VGym8oDpp881yimHA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/protocol-http': 3.212.0
+      '@aws-sdk/types': 3.212.0
+      tslib: 2.4.1
+    dev: false
+
   /@aws-sdk/node-config-provider/3.208.0:
     resolution: {integrity: sha512-htjs1cDXYXEMwZ1q2vb7wfG3bOW4weWWkKcfT7vqzZKfTXoMH2mPpJIXnPE1PxXerOLXHGUU8qqhfl6LxjlnfQ==}
     engines: {node: '>=14.0.0'}
@@ -490,6 +903,16 @@ packages:
       '@aws-sdk/property-provider': 3.208.0
       '@aws-sdk/shared-ini-file-loader': 3.208.0
       '@aws-sdk/types': 3.208.0
+      tslib: 2.4.1
+    dev: false
+
+  /@aws-sdk/node-config-provider/3.212.0:
+    resolution: {integrity: sha512-8AfOEDPe/D9DccUgredYg07GH2jrw07FCTyA1Pug5Hgbas7w14zbhLyQB0l6gcOJEuh34e/7oV9hN3s1hctnJg==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/property-provider': 3.212.0
+      '@aws-sdk/shared-ini-file-loader': 3.212.0
+      '@aws-sdk/types': 3.212.0
       tslib: 2.4.1
     dev: false
 
@@ -504,6 +927,17 @@ packages:
       tslib: 2.4.1
     dev: false
 
+  /@aws-sdk/node-http-handler/3.212.0:
+    resolution: {integrity: sha512-wt4jK8HeYMjuQbWB4+Xt/nGyTvIwtLhm0SHcRgcoTsUjEiaPio/xNanyBWhPSUM87jpyG6bQMCzUtDbPeLqhkA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/abort-controller': 3.212.0
+      '@aws-sdk/protocol-http': 3.212.0
+      '@aws-sdk/querystring-builder': 3.212.0
+      '@aws-sdk/types': 3.212.0
+      tslib: 2.4.1
+    dev: false
+
   /@aws-sdk/property-provider/3.208.0:
     resolution: {integrity: sha512-aUhfuwXjZ5TGzLhBstuAMmbnxHXeSGhzoIS8yy465ifgc95p6cHFZf+ZibgwgCMaGrKlTDCia2zwwpKQHN+4cw==}
     engines: {node: '>=14.0.0'}
@@ -512,11 +946,27 @@ packages:
       tslib: 2.4.1
     dev: false
 
+  /@aws-sdk/property-provider/3.212.0:
+    resolution: {integrity: sha512-NMCIABfw3VZ7Vtn6iSeZRuSToRLxIHq0eGoUgO7T4fUp3U5vqYt28A5UY65KB9ifUPpNSllEG3EhEqs5qFw5+w==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.212.0
+      tslib: 2.4.1
+    dev: false
+
   /@aws-sdk/protocol-http/3.208.0:
     resolution: {integrity: sha512-Sr9dmaW0Z9X9s16NHZn94efLRpaqLyLqABFPgjqE8cYP6eLX/VrmZGNR62GFVxCiyEEpVxy4Ddk1YkbRwnuonA==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-sdk/types': 3.208.0
+      tslib: 2.4.1
+    dev: false
+
+  /@aws-sdk/protocol-http/3.212.0:
+    resolution: {integrity: sha512-EhkLPQC2TeqC3RGKfW87zoKj/gsWS4JJlRl5U6KMXejBMKQPzuopUiF9gQJ2iuou9BT8B+RsG2qgSHzrxp6lKw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.212.0
       tslib: 2.4.1
     dev: false
 
@@ -529,6 +979,15 @@ packages:
       tslib: 2.4.1
     dev: false
 
+  /@aws-sdk/querystring-builder/3.212.0:
+    resolution: {integrity: sha512-4CaQstj0Aki3vc96Z0d481raNagmy9gnJtIv6yveATJ/57lk/RUv2WtTUOzpFKv/oNx5khix2tpbRqK9nCUxVg==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.212.0
+      '@aws-sdk/util-uri-escape': 3.201.0
+      tslib: 2.4.1
+    dev: false
+
   /@aws-sdk/querystring-parser/3.208.0:
     resolution: {integrity: sha512-dVVLdP3il9bJX74/BNBjFn59XrEVBUZ4xSKYH6t7dgSz9uSu8DcT4pPzwaq+/94dVewCW3zq2jVA1iw1rK7JVQ==}
     engines: {node: '>=14.0.0'}
@@ -537,8 +996,21 @@ packages:
       tslib: 2.4.1
     dev: false
 
+  /@aws-sdk/querystring-parser/3.212.0:
+    resolution: {integrity: sha512-ttarfAHMOYKgFHeBdgXID9SlNS7erH4gavN3fvf5R1RliCytUnzsTTvqa7CmVBFy0Xc/2yA+/6FFDKlOsS8tRg==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.212.0
+      tslib: 2.4.1
+    dev: false
+
   /@aws-sdk/service-error-classification/3.208.0:
     resolution: {integrity: sha512-ZZWV3AOTd8UDcfXCNoQ8v4sHaTgFxGaXWO0NHHgqFbVYr1d+8EXQiOy/v8JsY1jrfoXBWXptTOcioCTeM0xBpw==}
+    engines: {node: '>=14.0.0'}
+    dev: false
+
+  /@aws-sdk/service-error-classification/3.212.0:
+    resolution: {integrity: sha512-jCv+uuFq4yGjP8FoCmoOGqnKNHHREDOFf7OxVSCluGMg2LXHfGxxqkqNFJlT3p+QdEp323GSWFY+PUsMJy7BLQ==}
     engines: {node: '>=14.0.0'}
     dev: false
 
@@ -547,6 +1019,14 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-sdk/types': 3.208.0
+      tslib: 2.4.1
+    dev: false
+
+  /@aws-sdk/shared-ini-file-loader/3.212.0:
+    resolution: {integrity: sha512-wKWqCA1oU57V//D3uAjQKGGj6rm6YKH4pWIU38Ypb/xNafiB7C51KtwpQVsS2HCNfmGrD03sGLKEZCSy9jvIlA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.212.0
       tslib: 2.4.1
     dev: false
 
@@ -562,6 +1042,18 @@ packages:
       tslib: 2.4.1
     dev: false
 
+  /@aws-sdk/signature-v4/3.212.0:
+    resolution: {integrity: sha512-tCrzWA60AWGDRmY9OyUrG0BzD+dDbAtHSqcY2LchGHOlMmv501/WXBIvn9fDfKp8GJj6Lb3VcG9cY1jCuKKcmg==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/is-array-buffer': 3.201.0
+      '@aws-sdk/types': 3.212.0
+      '@aws-sdk/util-hex-encoding': 3.201.0
+      '@aws-sdk/util-middleware': 3.212.0
+      '@aws-sdk/util-uri-escape': 3.201.0
+      tslib: 2.4.1
+    dev: false
+
   /@aws-sdk/smithy-client/3.208.0:
     resolution: {integrity: sha512-4SGPAs7ZtG9AUYknJNkZTs+ww1cpdcPth5te+R/dN4anUbqtL2qvmbdZJ+8rzdAZKndXu0huKE1OZrR3COLciw==}
     engines: {node: '>=14.0.0'}
@@ -571,8 +1063,35 @@ packages:
       tslib: 2.4.1
     dev: false
 
+  /@aws-sdk/smithy-client/3.212.0:
+    resolution: {integrity: sha512-dQUlM/eltp9JVEVQWGxU/6Or8jGQWK5mgmbP+BUHkfDgoMIeOFksIYon211KhE18EjoGgav1mr4/HHlcnekI2w==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/middleware-stack': 3.212.0
+      '@aws-sdk/types': 3.212.0
+      tslib: 2.4.1
+    dev: false
+
+  /@aws-sdk/token-providers/3.212.0:
+    resolution: {integrity: sha512-pTe4PM14b58nbfvIP9B0zW5dUIxEb/ALVzSLuxpJwJRI51E5QZmXJMT3P77MUd6niqKw0cRrnEHIgznD67JHSg==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/client-sso-oidc': 3.212.0
+      '@aws-sdk/property-provider': 3.212.0
+      '@aws-sdk/shared-ini-file-loader': 3.212.0
+      '@aws-sdk/types': 3.212.0
+      tslib: 2.4.1
+    transitivePeerDependencies:
+      - aws-crt
+    dev: false
+
   /@aws-sdk/types/3.208.0:
     resolution: {integrity: sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw==}
+    engines: {node: '>=14.0.0'}
+    dev: false
+
+  /@aws-sdk/types/3.212.0:
+    resolution: {integrity: sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w==}
     engines: {node: '>=14.0.0'}
     dev: false
 
@@ -581,6 +1100,14 @@ packages:
     dependencies:
       '@aws-sdk/querystring-parser': 3.208.0
       '@aws-sdk/types': 3.208.0
+      tslib: 2.4.1
+    dev: false
+
+  /@aws-sdk/url-parser/3.212.0:
+    resolution: {integrity: sha512-mTUQQRcVYqur7aHDuDMDKxN7Yr/5kIZB1RtMjIwtimTcf7TZaskN6sLTPo42YgASM6XQQhJECZaOE7Ow16i6Mg==}
+    dependencies:
+      '@aws-sdk/querystring-parser': 3.212.0
+      '@aws-sdk/types': 3.212.0
       tslib: 2.4.1
     dev: false
 
@@ -644,6 +1171,16 @@ packages:
       tslib: 2.4.1
     dev: false
 
+  /@aws-sdk/util-defaults-mode-browser/3.212.0:
+    resolution: {integrity: sha512-tAs9+/lTtil545kyCqy7qjnnCq4S2S+4kBhHXgwRNPT85Nx5XCEEheWH6VZ45YufRaiRNFfX0n+odDwzDaev6g==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@aws-sdk/property-provider': 3.212.0
+      '@aws-sdk/types': 3.212.0
+      bowser: 2.11.0
+      tslib: 2.4.1
+    dev: false
+
   /@aws-sdk/util-defaults-mode-node/3.208.0:
     resolution: {integrity: sha512-y9dENqcmiUb7/D3uwJsE/fV+RZ9CUc/cs4OcofO81sU29xz8Fg/XQarjSdGVZMTnrDd190GXymMcB4qpOYhtPw==}
     engines: {node: '>= 10.0.0'}
@@ -656,11 +1193,31 @@ packages:
       tslib: 2.4.1
     dev: false
 
+  /@aws-sdk/util-defaults-mode-node/3.212.0:
+    resolution: {integrity: sha512-fNl1IDqn1mAoiM2Xv5KGAczXHy2+tPlouunIEePnQKTq0pzT3WqR13qleTfu1EcEz1oyGnDRoK91aP61Jxh3OQ==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@aws-sdk/config-resolver': 3.212.0
+      '@aws-sdk/credential-provider-imds': 3.212.0
+      '@aws-sdk/node-config-provider': 3.212.0
+      '@aws-sdk/property-provider': 3.212.0
+      '@aws-sdk/types': 3.212.0
+      tslib: 2.4.1
+    dev: false
+
   /@aws-sdk/util-endpoints/3.208.0:
     resolution: {integrity: sha512-FGJA07iEbC883bAaw0qtDrly5Y+1nR3ic+OOzGX2AsSgaeVAc1j8Lgg3br7ofBbr8p81ec6zN4syy4v7V0Wb0A==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-sdk/types': 3.208.0
+      tslib: 2.4.1
+    dev: false
+
+  /@aws-sdk/util-endpoints/3.212.0:
+    resolution: {integrity: sha512-/ADfvrZwhzUphre3pliO290IFOflvHyBBEaKn9WfRQ5veZxl+CuOEjxkwTJfHUrfWbh+xpCuOewWVLCptmoC4A==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.212.0
       tslib: 2.4.1
     dev: false
 
@@ -694,6 +1251,13 @@ packages:
       tslib: 2.4.1
     dev: false
 
+  /@aws-sdk/util-middleware/3.212.0:
+    resolution: {integrity: sha512-621glUpwVKJRB8QxRG/5cAKIq8LKPdl/l8CS7vDg34f6j9BJmP5YVPcTzzQ6iskQAblkndiBAnSjp7kGujxuGg==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      tslib: 2.4.1
+    dev: false
+
   /@aws-sdk/util-uri-escape/3.201.0:
     resolution: {integrity: sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==}
     engines: {node: '>=14.0.0'}
@@ -709,6 +1273,14 @@ packages:
       tslib: 2.4.1
     dev: false
 
+  /@aws-sdk/util-user-agent-browser/3.212.0:
+    resolution: {integrity: sha512-xXz16ge9NdKCwlD+952rfvgHdDe+pbCavbVMNdR60joHq5KYGR1e02l0LRNVe48/C9dAo2ezeJ+YnTPaw3Yl8Q==}
+    dependencies:
+      '@aws-sdk/types': 3.212.0
+      bowser: 2.11.0
+      tslib: 2.4.1
+    dev: false
+
   /@aws-sdk/util-user-agent-node/3.208.0:
     resolution: {integrity: sha512-T7V3TTc+NdcHgITo8yMUDs/qR0wfPjURUrCixHPtqYkqvhoF6YrHUAoCbOcz7SG/Tsm2GgSKAHB4ip9D2QLg4g==}
     engines: {node: '>=14.0.0'}
@@ -720,6 +1292,20 @@ packages:
     dependencies:
       '@aws-sdk/node-config-provider': 3.208.0
       '@aws-sdk/types': 3.208.0
+      tslib: 2.4.1
+    dev: false
+
+  /@aws-sdk/util-user-agent-node/3.212.0:
+    resolution: {integrity: sha512-HE8VwtMtTXGkwUjryNpy+qyg7wrQxCGplDP59yo0YVn86B5f9nhRi/2jRAsKo9yf94iP7PXAz65TY9+KJC8UIg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      aws-crt: '>=1.0.0'
+    peerDependenciesMeta:
+      aws-crt:
+        optional: true
+    dependencies:
+      '@aws-sdk/node-config-provider': 3.212.0
+      '@aws-sdk/types': 3.212.0
       tslib: 2.4.1
     dev: false
 
@@ -743,6 +1329,15 @@ packages:
     dependencies:
       '@aws-sdk/abort-controller': 3.208.0
       '@aws-sdk/types': 3.208.0
+      tslib: 2.4.1
+    dev: false
+
+  /@aws-sdk/util-waiter/3.212.0:
+    resolution: {integrity: sha512-TsmNpXpefq414PrHWKO35e5YFGB/MyQBZ6Ia8+hs6wZgd7rrUFghC4yjn8eCRpnfpdegEsWGcQZ/qeyMafgvcg==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/abort-controller': 3.212.0
+      '@aws-sdk/types': 3.212.0
       tslib: 2.4.1
     dev: false
 
@@ -876,6 +1471,11 @@ packages:
   /dataloader/1.4.0:
     resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
     dev: true
+
+  /date-fns/2.29.3:
+    resolution: {integrity: sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==}
+    engines: {node: '>=0.11'}
+    dev: false
 
   /dateformat/3.0.3:
     resolution: {integrity: sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==}

--- a/proto/depot/cloud/v2/cloud.proto
+++ b/proto/depot/cloud/v2/cloud.proto
@@ -9,6 +9,7 @@ service CloudService {
   rpc ReportCurrentState(ReportCurrentStateRequest) returns (ReportCurrentStateResponse) {}
   rpc ReportErrors(ReportErrorsRequest) returns (ReportErrorsResponse);
   rpc ReportHealth(stream ReportHealthRequest) returns (ReportHealthResponse);
+  rpc GetActiveAgentVersion(GetActiveAgentVersionRequest) returns (GetActiveAgentVersionResponse);
 }
 
 // Messages
@@ -114,6 +115,14 @@ message ReportHealthRequest {
 }
 
 message ReportHealthResponse {}
+
+message GetActiveAgentVersionRequest {
+  string connection_id = 1;
+}
+
+message GetActiveAgentVersionResponse {
+  string newer_than = 1;
+}
 
 // Objects
 

--- a/src/handlers/updater.ts
+++ b/src/handlers/updater.ts
@@ -1,0 +1,54 @@
+import {DescribeTasksCommand, ECSClient, ListTasksCommand, StopTaskCommand} from '@aws-sdk/client-ecs'
+import {parseISO} from 'date-fns'
+import {sleep} from '../utils/common'
+import {CLOUD_AGENT_CONNECTION_ID} from '../utils/env'
+import {client} from '../utils/grpc'
+import {logger} from '../utils/logger'
+
+const ecs = new ECSClient({})
+const cluster = process.env.CLOUD_AGENT_CLUSTER_ARN
+const serviceName = process.env.CLOUD_AGENT_SERVICE_NAME
+
+export async function startUpdater() {
+  while (true) {
+    try {
+      await checkForUpdates()
+    } catch (err: any) {
+      const message: string = err.message || `${err}`
+      logger.error(message)
+      await client.reportErrors({connectionId: CLOUD_AGENT_CONNECTION_ID, errors: [message]})
+    }
+    await sleep(1000 * 60)
+  }
+}
+
+// Get the newer than date from the API, stop any tasks older than that date
+async function checkForUpdates() {
+  const req = await client.getActiveAgentVersion({connectionId: CLOUD_AGENT_CONNECTION_ID})
+  const newerThan = parseISO(req.newerThan)
+
+  const {taskArns} = await ecs.send(new ListTasksCommand({cluster, serviceName}))
+  if (!taskArns || taskArns.length === 0) return
+  const {tasks} = await ecs.send(new DescribeTasksCommand({cluster, tasks: taskArns}))
+  if (!tasks) return
+
+  for (const task of tasks) {
+    if (!task.startedAt) continue
+    if (task.startedAt.getTime() >= newerThan.getTime()) continue
+    const desiredStatus = task.desiredStatus as TaskLifecycle
+    if (desiredStatus !== 'RUNNING') continue
+    console.log('Found old task to upgrade', task.taskArn)
+    await ecs.send(new StopTaskCommand({cluster, task: task.taskArn, reason: 'Upgrading'}))
+  }
+}
+
+type TaskLifecycle =
+  | 'PROVISIONING'
+  | 'PENDING'
+  | 'ACTIVATING'
+  | 'RUNNING'
+  | 'DEACTIVATING'
+  | 'STOPPING'
+  | 'DEPROVISIONING'
+  | 'STOPPED'
+  | 'DELETED'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import {startHealthStream} from './handlers/health'
 import {startStateStream} from './handlers/state'
+import {startUpdater} from './handlers/updater'
 import {sleep} from './utils/common'
 import {CLOUD_AGENT_CONNECTION_ID} from './utils/env'
 import {client} from './utils/grpc'
@@ -10,7 +11,7 @@ async function main() {
 
   while (true) {
     try {
-      await Promise.all([startHealthStream(), startStateStream()])
+      await Promise.all([startHealthStream(), startStateStream(), startUpdater()])
     } catch (err: any) {
       const message: string = err.message || `${err}`
       logger.error(message)

--- a/src/proto/depot/cloud/v2/cloud.ts
+++ b/src/proto/depot/cloud/v2/cloud.ts
@@ -303,6 +303,14 @@ export interface ReportHealthRequest {
 
 export interface ReportHealthResponse {}
 
+export interface GetActiveAgentVersionRequest {
+  connectionId: string
+}
+
+export interface GetActiveAgentVersionResponse {
+  newerThan: string
+}
+
 export interface CloudState {
   state?: {$case: 'aws'; aws: CloudState_Aws}
 }
@@ -1103,6 +1111,100 @@ export const ReportHealthResponse = {
   },
 }
 
+function createBaseGetActiveAgentVersionRequest(): GetActiveAgentVersionRequest {
+  return {connectionId: ''}
+}
+
+export const GetActiveAgentVersionRequest = {
+  encode(message: GetActiveAgentVersionRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.connectionId !== '') {
+      writer.uint32(10).string(message.connectionId)
+    }
+    return writer
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): GetActiveAgentVersionRequest {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input)
+    let end = length === undefined ? reader.len : reader.pos + length
+    const message = createBaseGetActiveAgentVersionRequest()
+    while (reader.pos < end) {
+      const tag = reader.uint32()
+      switch (tag >>> 3) {
+        case 1:
+          message.connectionId = reader.string()
+          break
+        default:
+          reader.skipType(tag & 7)
+          break
+      }
+    }
+    return message
+  },
+
+  fromJSON(object: any): GetActiveAgentVersionRequest {
+    return {connectionId: isSet(object.connectionId) ? String(object.connectionId) : ''}
+  },
+
+  toJSON(message: GetActiveAgentVersionRequest): unknown {
+    const obj: any = {}
+    message.connectionId !== undefined && (obj.connectionId = message.connectionId)
+    return obj
+  },
+
+  fromPartial(object: DeepPartial<GetActiveAgentVersionRequest>): GetActiveAgentVersionRequest {
+    const message = createBaseGetActiveAgentVersionRequest()
+    message.connectionId = object.connectionId ?? ''
+    return message
+  },
+}
+
+function createBaseGetActiveAgentVersionResponse(): GetActiveAgentVersionResponse {
+  return {newerThan: ''}
+}
+
+export const GetActiveAgentVersionResponse = {
+  encode(message: GetActiveAgentVersionResponse, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.newerThan !== '') {
+      writer.uint32(10).string(message.newerThan)
+    }
+    return writer
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): GetActiveAgentVersionResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input)
+    let end = length === undefined ? reader.len : reader.pos + length
+    const message = createBaseGetActiveAgentVersionResponse()
+    while (reader.pos < end) {
+      const tag = reader.uint32()
+      switch (tag >>> 3) {
+        case 1:
+          message.newerThan = reader.string()
+          break
+        default:
+          reader.skipType(tag & 7)
+          break
+      }
+    }
+    return message
+  },
+
+  fromJSON(object: any): GetActiveAgentVersionResponse {
+    return {newerThan: isSet(object.newerThan) ? String(object.newerThan) : ''}
+  },
+
+  toJSON(message: GetActiveAgentVersionResponse): unknown {
+    const obj: any = {}
+    message.newerThan !== undefined && (obj.newerThan = message.newerThan)
+    return obj
+  },
+
+  fromPartial(object: DeepPartial<GetActiveAgentVersionResponse>): GetActiveAgentVersionResponse {
+    const message = createBaseGetActiveAgentVersionResponse()
+    message.newerThan = object.newerThan ?? ''
+    return message
+  },
+}
+
 function createBaseCloudState(): CloudState {
   return {state: undefined}
 }
@@ -1356,6 +1458,14 @@ export const CloudServiceDefinition = {
       responseStream: false,
       options: {},
     },
+    getActiveAgentVersion: {
+      name: 'GetActiveAgentVersion',
+      requestType: GetActiveAgentVersionRequest,
+      requestStream: false,
+      responseType: GetActiveAgentVersionResponse,
+      responseStream: false,
+      options: {},
+    },
   },
 } as const
 
@@ -1376,6 +1486,10 @@ export interface CloudServiceServiceImplementation<CallContextExt = {}> {
     request: AsyncIterable<ReportHealthRequest>,
     context: CallContext & CallContextExt,
   ): Promise<DeepPartial<ReportHealthResponse>>
+  getActiveAgentVersion(
+    request: GetActiveAgentVersionRequest,
+    context: CallContext & CallContextExt,
+  ): Promise<DeepPartial<GetActiveAgentVersionResponse>>
 }
 
 export interface CloudServiceClient<CallOptionsExt = {}> {
@@ -1395,6 +1509,10 @@ export interface CloudServiceClient<CallOptionsExt = {}> {
     request: AsyncIterable<DeepPartial<ReportHealthRequest>>,
     options?: CallOptions & CallOptionsExt,
   ): Promise<ReportHealthResponse>
+  getActiveAgentVersion(
+    request: DeepPartial<GetActiveAgentVersionRequest>,
+    options?: CallOptions & CallOptionsExt,
+  ): Promise<GetActiveAgentVersionResponse>
 }
 
 type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined


### PR DESCRIPTION
Adds a loop that checks for an update date from the API and stops all running cloud-agent tasks older than that date.