### PR TITLE
Launch 40GB ephemeral disks

### DIFF
--- a/src/utils/aws.ts
+++ b/src/utils/aws.ts
@@ -241,6 +241,17 @@ systemctl start machine-agent.service
           SubnetId: CLOUD_AGENT_AWS_SUBNET_ID,
         },
       ],
+      BlockDeviceMappings: [
+        {
+          DeviceName: '/dev/xvda',
+          Ebs: {
+            VolumeSize: 40,
+            VolumeType: 'gp3',
+            DeleteOnTermination: true,
+            Encrypted: true,
+          },
+        },
+      ],
       MaxCount: 1,
       MinCount: 1,
       UserData: Buffer.from(userData).toString('base64'),


### PR DESCRIPTION
This change increases ephemeral disk sizes from 10GB to 40GB. We will share the additional 30GB with BuildKit's ephemeral executor directory.