### PR TITLE
Enforce IMDSv2 for launched instances

### DIFF
--- a/src/utils/aws.ts
+++ b/src/utils/aws.ts
@@ -261,6 +261,7 @@ systemctl start machine-agent.service
       ],
       MaxCount: 1,
       MinCount: 1,
+      MetadataOptions: {HttpTokens: 'required'},
       UserData: Buffer.from(userData).toString('base64'),
     }),
   )


### PR DESCRIPTION
We don't give launched instances any IAM roles anyways, but this change protects us from IMDSv1 if we ever do.