### PR TITLE
Don't throw if error reporting error

### DIFF
--- a/src/handlers/state.ts
+++ b/src/handlers/state.ts
@@ -15,6 +15,7 @@ export async function startStateStream(signal: AbortSignal) {
       const stream = client.getDesiredState({connectionId: CLOUD_AGENT_CONNECTION_ID}, {signal})
 
       for await (const response of stream) {
+        if (signal.aborted) return
         currentState = await getCurrentState()
         const errors = await reconcile(response, currentState)
         for (const error of errors) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,7 @@
 import {startHealthStream} from './handlers/health'
 import {startStateStream} from './handlers/state'
 import {startUpdater} from './handlers/updater'
-import {sleep} from './utils/common'
 import {CLOUD_AGENT_VERSION} from './utils/env'
-import {reportError} from './utils/errors'
 import {logger} from './utils/logger'
 
 const controller = new AbortController()
@@ -32,14 +30,9 @@ async function main() {
   trapShutdown('SIGINT')
   trapShutdown('SIGTERM')
 
-  while (!signal.aborted) {
-    try {
-      await Promise.all([startHealthStream(signal), startStateStream(signal), startUpdater(signal)])
-    } catch (err: any) {
-      await reportError(err)
-    }
-    await sleep(1000)
-  }
+  startHealthStream(signal)
+  startStateStream(signal)
+  startUpdater(signal)
 }
 
 main().catch((err) => {

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -4,8 +4,12 @@ import {client} from './grpc'
 import {logger} from './logger'
 
 export async function reportError(err: any) {
-  if (isAbortError(err)) return
-  const message: string = err.message || `${err}`
-  logger.error(message)
-  await client.reportErrors({connectionId: CLOUD_AGENT_CONNECTION_ID, errors: [message]})
+  try {
+    if (isAbortError(err)) return
+    const message: string = err.message || `${err}`
+    logger.error(message)
+    await client.reportErrors({connectionId: CLOUD_AGENT_CONNECTION_ID, errors: [message]})
+  } catch (err: any) {
+    logger.error(`Failed to report error: ${err.message || err}`)
+  }
 }


### PR DESCRIPTION
There was a case where we could throw when reporting an error, causing multiple update streams to start. This ensures we do not throw on errors reporting errors.