### PR TITLE
feat: optionally override machine instance type

### DIFF
--- a/proto/depot/cloud/v2/cloud.proto
+++ b/proto/depot/cloud/v2/cloud.proto
@@ -31,6 +31,8 @@ message GetDesiredStateResponse {
     Architecture architecture = 4;
     string image = 5;
     SecurityGroup security_group = 6;
+    // Optionally override the instance type of the launch template.
+    optional string instance_type = 7;
   }
 
   message NewVolume {

--- a/src/proto/depot/cloud/v2/cloud_pb.ts
+++ b/src/proto/depot/cloud/v2/cloud_pb.ts
@@ -317,6 +317,13 @@ export class GetDesiredStateResponse_NewMachine extends Message<GetDesiredStateR
    */
   securityGroup = GetDesiredStateResponse_SecurityGroup.UNSPECIFIED
 
+  /**
+   * Optionally override the instance type of the launch template.
+   *
+   * @generated from field: optional string instance_type = 7;
+   */
+  instanceType?: string
+
   constructor(data?: PartialMessage<GetDesiredStateResponse_NewMachine>) {
     super()
     proto3.util.initPartial(data, this)
@@ -331,6 +338,7 @@ export class GetDesiredStateResponse_NewMachine extends Message<GetDesiredStateR
     {no: 4, name: 'architecture', kind: 'enum', T: proto3.getEnumType(GetDesiredStateResponse_Architecture)},
     {no: 5, name: 'image', kind: 'scalar', T: 9 /* ScalarType.STRING */},
     {no: 6, name: 'security_group', kind: 'enum', T: proto3.getEnumType(GetDesiredStateResponse_SecurityGroup)},
+    {no: 7, name: 'instance_type', kind: 'scalar', T: 9 /* ScalarType.STRING */, opt: true},
   ])
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): GetDesiredStateResponse_NewMachine {

--- a/src/utils/aws.ts
+++ b/src/utils/aws.ts
@@ -222,6 +222,8 @@ systemctl start machine-agent.service
             ? process.env.CLOUD_AGENT_AWS_LAUNCH_TEMPLATE_X86
             : process.env.CLOUD_AGENT_AWS_LAUNCH_TEMPLATE_ARM,
       },
+      // Optional instance type override; otherwise will take the instance type from the launch templates.
+      InstanceType: machine.instanceType ?? undefined,
       ImageId: machine.image,
       TagSpecifications: [
         {


### PR DESCRIPTION
In order to launch with special machine instances like those with GPUs we need to override the launch template.