### PR TITLE
feat: add runtime-configuration switch between aws and fly

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import {startHealthStream} from './handlers/health'
-import {startStateStream} from './handlers/state'
+import {AwsProvider, FlyProvider, startStateStream} from './handlers/state'
 import {startUpdater} from './handlers/updater'
 import {startVolumeStream} from './handlers/volumes'
 import {writeCephConf} from './utils/ceph'
@@ -8,6 +8,7 @@ import {
   CLOUD_AGENT_CEPH_CONFIG,
   CLOUD_AGENT_CEPH_KEY,
   CLOUD_AGENT_CONNECTION_ID,
+  CLOUD_AGENT_PROVIDER,
   CLOUD_AGENT_VERSION,
 } from './utils/env'
 import {client} from './utils/grpc'
@@ -48,7 +49,18 @@ async function main() {
   }
 
   startHealthStream(signal)
-  startStateStream(signal)
+
+  switch (CLOUD_AGENT_PROVIDER) {
+    case 'fly':
+      startStateStream(signal, FlyProvider)
+      break
+    case 'aws':
+      startStateStream(signal, AwsProvider)
+      break
+    default:
+      startStateStream(signal, AwsProvider)
+  }
+
   startUpdater(signal)
   if (CLOUD_AGENT_CEPH_CONFIG && CLOUD_AGENT_CEPH_KEY) {
     await writeCephConf('client.admin', CLOUD_AGENT_CEPH_CONFIG, CLOUD_AGENT_CEPH_KEY)

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -2,6 +2,9 @@ import {config} from 'dotenv'
 
 config()
 
+// CLOUD_AGENT_PROVIDER defines the cloud provider. It defaults to 'aws' but can be 'fly'.
+export const CLOUD_AGENT_PROVIDER = process.env.CLOUD_AGENT_PROVIDER ?? 'aws'
+
 export const CLOUD_AGENT_API_URL = process.env.CLOUD_AGENT_API_URL ?? 'https://api.depot.dev'
 
 export const CLOUD_AGENT_CONNECTION_ID = requiredEnv('CLOUD_AGENT_CONNECTION_ID')


### PR DESCRIPTION
This uses a new env var `CLOUD_AGENT_PROVIDER` to switch between fly and aws.