### PR TITLE
feat: allow image spec naming to avoid constructing them

### DIFF
--- a/proto/depot/cloud/v2/cloud.proto
+++ b/proto/depot/cloud/v2/cloud.proto
@@ -222,6 +222,8 @@ message CreateVolumeAction {
 
 message CreateVolumeUpdate {
   string volume_name = 1;
+  // Image ID to use for the volume.
+  string image_spec = 2;
 }
 
 message TrimVolumeAction {
@@ -236,6 +238,7 @@ message ResizeVolumeAction {
   string volume_name = 1;
   // Size in GB
   int32 size = 3;
+  string image_spec = 4;
 }
 
 message ResizeVolumeUpdate {
@@ -244,6 +247,7 @@ message ResizeVolumeUpdate {
 
 message DeleteVolumeAction {
   string volume_name = 1;
+  string image_spec = 2;
 }
 
 message DeleteVolumeUpdate {
@@ -276,10 +280,12 @@ message DeleteClientUpdate {
 message AuthorizeClientAction {
   string volume_name = 1;
   string client_name = 2;
+  string image_spec = 3;
 }
 
 // rbd device map {image_spec} --name {client_name} --keyfile {file w/ key}
 message AuthorizeClientUpdate {
   string client_name = 1;
   string volume_name = 2;
+  string image_spec = 3;
 }

--- a/src/handlers/volumes.ts
+++ b/src/handlers/volumes.ts
@@ -104,6 +104,7 @@ async function createVolume({volumeName, size}: CreateVolumeAction): Promise<Pla
       case: 'createVolume',
       value: {
         volumeName,
+        imageSpec,
       },
     },
   }
@@ -139,10 +140,17 @@ async function trimVolume({volumeName}: TrimVolumeAction): Promise<PlainMessage<
   }
 }
 
-async function deleteVolume({volumeName}: DeleteVolumeAction): Promise<PlainMessage<ReportVolumeUpdatesRequest>> {
-  const imageSpec = newImageSpec(volumeName)
+async function deleteVolume({
+  volumeName,
+  imageSpec,
+}: DeleteVolumeAction): Promise<PlainMessage<ReportVolumeUpdatesRequest>> {
+  if (imageSpec) {
+    await imageRm(newImageSpec(imageSpec))
+  } else {
+    await imageRm(newImageSpec(volumeName))
+  }
+
   const poolSpec = newPoolSpec(volumeName)
-  await imageRm(imageSpec)
   await namespaceRm(poolSpec)
 
   return {
@@ -178,6 +186,7 @@ async function createClient({
 async function authorizeClient({
   volumeName,
   clientName: plainClientName,
+  imageSpec,
 }: AuthorizeClientAction): Promise<PlainMessage<ReportVolumeUpdatesRequest>> {
   const osdProfile = newOsdProfile(volumeName)
   const clientName = newClientName(plainClientName)
@@ -189,6 +198,7 @@ async function authorizeClient({
       value: {
         clientName,
         volumeName,
+        imageSpec,
       },
     },
   }

--- a/src/proto/depot/cloud/v2/cloud_pb.ts
+++ b/src/proto/depot/cloud/v2/cloud_pb.ts
@@ -1633,6 +1633,13 @@ export class CreateVolumeUpdate extends Message<CreateVolumeUpdate> {
    */
   volumeName = ''
 
+  /**
+   * Image ID to use for the volume.
+   *
+   * @generated from field: string image_spec = 2;
+   */
+  imageSpec = ''
+
   constructor(data?: PartialMessage<CreateVolumeUpdate>) {
     super()
     proto3.util.initPartial(data, this)
@@ -1642,6 +1649,7 @@ export class CreateVolumeUpdate extends Message<CreateVolumeUpdate> {
   static readonly typeName = 'depot.cloud.v2.CreateVolumeUpdate'
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     {no: 1, name: 'volume_name', kind: 'scalar', T: 9 /* ScalarType.STRING */},
+    {no: 2, name: 'image_spec', kind: 'scalar', T: 9 /* ScalarType.STRING */},
   ])
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): CreateVolumeUpdate {
@@ -1760,6 +1768,11 @@ export class ResizeVolumeAction extends Message<ResizeVolumeAction> {
    */
   size = 0
 
+  /**
+   * @generated from field: string image_spec = 4;
+   */
+  imageSpec = ''
+
   constructor(data?: PartialMessage<ResizeVolumeAction>) {
     super()
     proto3.util.initPartial(data, this)
@@ -1770,6 +1783,7 @@ export class ResizeVolumeAction extends Message<ResizeVolumeAction> {
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     {no: 1, name: 'volume_name', kind: 'scalar', T: 9 /* ScalarType.STRING */},
     {no: 3, name: 'size', kind: 'scalar', T: 5 /* ScalarType.INT32 */},
+    {no: 4, name: 'image_spec', kind: 'scalar', T: 9 /* ScalarType.STRING */},
   ])
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ResizeVolumeAction {
@@ -1841,6 +1855,11 @@ export class DeleteVolumeAction extends Message<DeleteVolumeAction> {
    */
   volumeName = ''
 
+  /**
+   * @generated from field: string image_spec = 2;
+   */
+  imageSpec = ''
+
   constructor(data?: PartialMessage<DeleteVolumeAction>) {
     super()
     proto3.util.initPartial(data, this)
@@ -1850,6 +1869,7 @@ export class DeleteVolumeAction extends Message<DeleteVolumeAction> {
   static readonly typeName = 'depot.cloud.v2.DeleteVolumeAction'
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     {no: 1, name: 'volume_name', kind: 'scalar', T: 9 /* ScalarType.STRING */},
+    {no: 2, name: 'image_spec', kind: 'scalar', T: 9 /* ScalarType.STRING */},
   ])
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): DeleteVolumeAction {
@@ -2107,6 +2127,11 @@ export class AuthorizeClientAction extends Message<AuthorizeClientAction> {
    */
   clientName = ''
 
+  /**
+   * @generated from field: string image_spec = 3;
+   */
+  imageSpec = ''
+
   constructor(data?: PartialMessage<AuthorizeClientAction>) {
     super()
     proto3.util.initPartial(data, this)
@@ -2117,6 +2142,7 @@ export class AuthorizeClientAction extends Message<AuthorizeClientAction> {
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     {no: 1, name: 'volume_name', kind: 'scalar', T: 9 /* ScalarType.STRING */},
     {no: 2, name: 'client_name', kind: 'scalar', T: 9 /* ScalarType.STRING */},
+    {no: 3, name: 'image_spec', kind: 'scalar', T: 9 /* ScalarType.STRING */},
   ])
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): AuthorizeClientAction {
@@ -2155,6 +2181,11 @@ export class AuthorizeClientUpdate extends Message<AuthorizeClientUpdate> {
    */
   volumeName = ''
 
+  /**
+   * @generated from field: string image_spec = 3;
+   */
+  imageSpec = ''
+
   constructor(data?: PartialMessage<AuthorizeClientUpdate>) {
     super()
     proto3.util.initPartial(data, this)
@@ -2165,6 +2196,7 @@ export class AuthorizeClientUpdate extends Message<AuthorizeClientUpdate> {
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     {no: 1, name: 'client_name', kind: 'scalar', T: 9 /* ScalarType.STRING */},
     {no: 2, name: 'volume_name', kind: 'scalar', T: 9 /* ScalarType.STRING */},
+    {no: 3, name: 'image_spec', kind: 'scalar', T: 9 /* ScalarType.STRING */},
   ])
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): AuthorizeClientUpdate {

--- a/src/utils/ceph.ts
+++ b/src/utils/ceph.ts
@@ -16,6 +16,10 @@ export function newPoolSpec(volumeName: string): PoolSpec {
 }
 
 export function newImageSpec(volumeName: string): ImageSpec {
+  // Assume that if the volume name contains a slash, it is already a full image spec.
+  if (volumeName.includes('/')) {
+    return volumeName as ImageSpec
+  }
   return `${POOL}/${volumeName}/${volumeName}` as ImageSpec
 }
 


### PR DESCRIPTION
This will help me handling snapshots and clones as I can specify full image specs rather than needing to tokenize.

This is backwards and forwards compatible.