### PR TITLE
fix: parse clone parent names correctly

### DIFF
--- a/src/handlers/volumes.ts
+++ b/src/handlers/volumes.ts
@@ -169,10 +169,10 @@ async function cloneVolume(
     console.error(`Invalid snapshot name: ${parentImageSpec}`)
     return null
   }
-  const [snapshotParentName] = parentImageSpec.split('@')
+  const [, parentVolume] = parentImageSpec.split('/')
   const snapshotSpec = newSnapshotSpec(parentImageSpec)
 
-  const cloneSpec = newCloneSpec(newPoolSpec(snapshotParentName), volumeName)
+  const cloneSpec = newCloneSpec(newPoolSpec(parentVolume), volumeName)
   await createClone(snapshotSpec, cloneSpec)
 
   return {


### PR DESCRIPTION
Previously, the split would take the entire parent name. However, we just need the parent image name and can assume the pool name for now.