### PR TITLE
fix: use namespace for ceph authorization

### DIFF
--- a/src/handlers/volumes.ts
+++ b/src/handlers/volumes.ts
@@ -278,7 +278,12 @@ async function authorizeClient({
   clientName: plainClientName,
   imageSpec,
 }: AuthorizeClientAction): Promise<PlainMessage<ReportVolumeUpdatesRequest>> {
-  const osdProfile = newOsdProfile(volumeName)
+  let namespace = volumeName
+  if (imageSpec && imageSpec.includes('/')) {
+    namespace = imageSpec.split('/')[1]
+  }
+
+  const osdProfile = newOsdProfile(namespace)
   const clientName = newClientName(plainClientName)
   await authCaps(osdProfile, clientName)
 

--- a/src/utils/ceph.ts
+++ b/src/utils/ceph.ts
@@ -31,9 +31,9 @@ export function newClientName(name: string): ClientName {
   return name as ClientName
 }
 
-export function newOsdProfile(volumeName: string): OsdProfile {
+export function newOsdProfile(namespace: string): OsdProfile {
   // Gives a user read-write access to the Ceph Block Devices in namespace.
-  return `profile rbd pool=${POOL} namespace=${volumeName}` as OsdProfile
+  return `profile rbd pool=${POOL} namespace=${namespace}` as OsdProfile
 }
 
 export function newSnapshotSpec(snapshotName: string): SnapshotSpec {


### PR DESCRIPTION
Previously, the volume name was assumed to be the namespace. This is not true for clones.

If the imageSpec is passed we now parse it to extract the namespace.