### PR TITLE
fix: skip updating if running in fly

### DIFF
--- a/src/handlers/updater.ts
+++ b/src/handlers/updater.ts
@@ -1,7 +1,7 @@
 import {DescribeTasksCommand, ECSClient, ListTasksCommand, StopTaskCommand} from '@aws-sdk/client-ecs'
 import {parseISO} from 'date-fns'
 import {sleep} from '../utils/common'
-import {CLOUD_AGENT_CONNECTION_ID} from '../utils/env'
+import {CLOUD_AGENT_CONNECTION_ID, CLOUD_AGENT_PROVIDER} from '../utils/env'
 import {reportError} from '../utils/errors'
 import {client} from '../utils/grpc'
 
@@ -23,6 +23,12 @@ export async function startUpdater(signal: AbortSignal) {
 // Get the newer than date from the API, stop any tasks older than that date
 async function checkForUpdates() {
   const req = await client.getActiveAgentVersion({connectionId: CLOUD_AGENT_CONNECTION_ID})
+
+  // TODO: handle updating fly cloud-agent.
+  if (CLOUD_AGENT_PROVIDER === 'fly') {
+    return
+  }
+
   const newerThan = parseISO(req.newerThan)
 
   const {taskArns} = await ecs.send(new ListTasksCommand({cluster, serviceName}))


### PR DESCRIPTION
Closes DEP-1610

We'll need to circle back and figure out how to update the fly container.