### PR TITLE
feat(fly): retry creating machines on capacity errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,5 @@ Update fly with:
 
 ```sh
 MACHINE_ID=$(flyctl machines list --app depot-cloud-agent -j|jq -r  '.[0].id')
-flyctl machine update $MACHINE_ID --app depot-cloud-agent --image ghcr.io/depot/cloud-agent:2.30.1 --yes
+flyctl machine update $MACHINE_ID --app depot-cloud-agent --image ghcr.io/depot/cloud-agent:2.30.2 --yes
 ```

--- a/proto/depot/cloud/v2/cloud.proto
+++ b/proto/depot/cloud/v2/cloud.proto
@@ -12,6 +12,8 @@ service CloudService {
   rpc ReportVolumeUpdates(ReportVolumeUpdatesRequest) returns (ReportVolumeUpdatesResponse) {}
 
   rpc GetDesiredStateUnary(GetDesiredStateUnaryRequest) returns (GetDesiredStateUnaryResponse) {}
+
+  rpc ReplaceVolume(ReplaceVolumeRequest) returns (ReplaceVolumeResponse) {}
 }
 
 // Messages
@@ -117,6 +119,13 @@ message GetDesiredStateResponse {
     int32 size = 2;
   }
 }
+
+message ReplaceVolumeRequest {
+  string connection_id = 1;
+  string id = 2;
+}
+
+message ReplaceVolumeResponse {}
 
 message ReportCurrentStateRequest {
   string connection_id = 1;

--- a/src/proto/depot/cloud/v2/cloud_connect.ts
+++ b/src/proto/depot/cloud/v2/cloud_connect.ts
@@ -13,6 +13,8 @@ import {
   GetDesiredStateUnaryResponse,
   ReconcileVolumesRequest,
   ReconcileVolumesResponse,
+  ReplaceVolumeRequest,
+  ReplaceVolumeResponse,
   ReportCurrentStateRequest,
   ReportCurrentStateResponse,
   ReportErrorsRequest,
@@ -99,6 +101,15 @@ export const CloudService = {
       name: 'GetDesiredStateUnary',
       I: GetDesiredStateUnaryRequest,
       O: GetDesiredStateUnaryResponse,
+      kind: MethodKind.Unary,
+    },
+    /**
+     * @generated from rpc depot.cloud.v2.CloudService.ReplaceVolume
+     */
+    replaceVolume: {
+      name: 'ReplaceVolume',
+      I: ReplaceVolumeRequest,
+      O: ReplaceVolumeResponse,
       kind: MethodKind.Unary,
     },
   },

--- a/src/proto/depot/cloud/v2/cloud_pb.ts
+++ b/src/proto/depot/cloud/v2/cloud_pb.ts
@@ -737,6 +737,85 @@ export class GetDesiredStateResponse_RootVolume extends Message<GetDesiredStateR
 }
 
 /**
+ * @generated from message depot.cloud.v2.ReplaceVolumeRequest
+ */
+export class ReplaceVolumeRequest extends Message<ReplaceVolumeRequest> {
+  /**
+   * @generated from field: string connection_id = 1;
+   */
+  connectionId = ''
+
+  /**
+   * @generated from field: string id = 2;
+   */
+  id = ''
+
+  constructor(data?: PartialMessage<ReplaceVolumeRequest>) {
+    super()
+    proto3.util.initPartial(data, this)
+  }
+
+  static readonly runtime: typeof proto3 = proto3
+  static readonly typeName = 'depot.cloud.v2.ReplaceVolumeRequest'
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    {no: 1, name: 'connection_id', kind: 'scalar', T: 9 /* ScalarType.STRING */},
+    {no: 2, name: 'id', kind: 'scalar', T: 9 /* ScalarType.STRING */},
+  ])
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ReplaceVolumeRequest {
+    return new ReplaceVolumeRequest().fromBinary(bytes, options)
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): ReplaceVolumeRequest {
+    return new ReplaceVolumeRequest().fromJson(jsonValue, options)
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): ReplaceVolumeRequest {
+    return new ReplaceVolumeRequest().fromJsonString(jsonString, options)
+  }
+
+  static equals(
+    a: ReplaceVolumeRequest | PlainMessage<ReplaceVolumeRequest> | undefined,
+    b: ReplaceVolumeRequest | PlainMessage<ReplaceVolumeRequest> | undefined,
+  ): boolean {
+    return proto3.util.equals(ReplaceVolumeRequest, a, b)
+  }
+}
+
+/**
+ * @generated from message depot.cloud.v2.ReplaceVolumeResponse
+ */
+export class ReplaceVolumeResponse extends Message<ReplaceVolumeResponse> {
+  constructor(data?: PartialMessage<ReplaceVolumeResponse>) {
+    super()
+    proto3.util.initPartial(data, this)
+  }
+
+  static readonly runtime: typeof proto3 = proto3
+  static readonly typeName = 'depot.cloud.v2.ReplaceVolumeResponse'
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [])
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ReplaceVolumeResponse {
+    return new ReplaceVolumeResponse().fromBinary(bytes, options)
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): ReplaceVolumeResponse {
+    return new ReplaceVolumeResponse().fromJson(jsonValue, options)
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): ReplaceVolumeResponse {
+    return new ReplaceVolumeResponse().fromJsonString(jsonString, options)
+  }
+
+  static equals(
+    a: ReplaceVolumeResponse | PlainMessage<ReplaceVolumeResponse> | undefined,
+    b: ReplaceVolumeResponse | PlainMessage<ReplaceVolumeResponse> | undefined,
+  ): boolean {
+    return proto3.util.equals(ReplaceVolumeResponse, a, b)
+  }
+}
+
+/**
  * @generated from message depot.cloud.v2.ReportCurrentStateRequest
  */
 export class ReportCurrentStateRequest extends Message<ReportCurrentStateRequest> {


### PR DESCRIPTION
In fly the volume is tied to a specific node.
Sometimes nodes are over-capacity and are unable to start machines.

To handle this situation we replace its volume to trigger recreation of the machine.