### PR TITLE
Optimize reconciliation loop

### DIFF
--- a/src/handlers/state.ts
+++ b/src/handlers/state.ts
@@ -35,7 +35,7 @@ export const FlyProvider: CloudProvider<FlyCurrentState> = {
 export async function startStateStream<T>(signal: AbortSignal, provider: CloudProvider<T>) {
   while (!signal.aborted) {
     try {
-      let currentState = await provider.getCurrentState()
+      const currentState = await provider.getCurrentState()
 
       await provider.reportCurrentState(currentState)
 

--- a/src/handlers/state.ts
+++ b/src/handlers/state.ts
@@ -17,7 +17,7 @@ import {client} from '../utils/grpc'
 interface CloudProvider<T> {
   getCurrentState(): Promise<T>
   reportCurrentState(currentState: T): Promise<void>
-  reconcile(response: GetDesiredStateResponse, state: T): Promise<string[]>
+  reconcile(response: GetDesiredStateResponse, state: T): Promise<void>
 }
 
 export const AwsProvider: CloudProvider<AwsCurrentState> = {
@@ -42,12 +42,7 @@ export async function startStateStream<T>(signal: AbortSignal, provider: CloudPr
       const response = await client.getDesiredState({clientId: clientID}, {signal})
       if (isEmptyResponse(response)) continue
 
-      currentState = await provider.getCurrentState()
-
-      const errors = await provider.reconcile(response, currentState)
-      for (const error of errors) {
-        await reportError(error)
-      }
+      await provider.reconcile(response, currentState)
     } catch (err: any) {
       if (err instanceof ConnectError && err.code === Code.FailedPrecondition) {
         // Connection lock was not acquired, sleep and retry

--- a/src/utils/scheduler.ts
+++ b/src/utils/scheduler.ts
@@ -1,0 +1,24 @@
+import {reportError} from './errors'
+
+const inProgressTasks = new Set<string>()
+
+/**
+ * Schedule an update to run, ensuring that only one update is running at a time.
+ */
+export async function scheduleTask(key: string, task: () => Promise<void>) {
+  if (inProgressTasks.has(key)) {
+    console.log(`Skipping ${key} because it is already in progress`)
+    return
+  }
+
+  try {
+    inProgressTasks.add(key)
+    console.log(`Accepted ${key}, starting task`)
+    return await task()
+  } catch (err) {
+    await reportError(err)
+  } finally {
+    inProgressTasks.delete(key)
+    console.log(`Task ${key} completed`)
+  }
+}


### PR DESCRIPTION
* Only fetch current state of the world once
* Execute state actions in parallel, like the ceph updates