### PR TITLE
log if multiple instances with the same machine ID are found

### DIFF
--- a/src/utils/aws.ts
+++ b/src/utils/aws.ts
@@ -237,6 +237,9 @@ async function runInstance(machine: GetDesiredStateResponse_NewMachine, subnetID
     }),
   )
   const instances = res.Reservations?.flatMap((r) => r.Instances || []) || []
+  if (instances.length > 1) {
+    console.log(`Multiple instances with the same machine-id! ${machine.id}`)
+  }
   if (instances.length > 0) {
     console.log(`Found existing ${instances.length} instances for machine ID ${machine.id}, skipping`)
     return


### PR DESCRIPTION
this should help us make sure that the duplicate machine bug is properly squashed