### PR TITLE
feat: support only handling volume only mode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import {
   CLOUD_AGENT_CONNECTION_ID,
   CLOUD_AGENT_PROVIDER,
   CLOUD_AGENT_VERSION,
+  CLOUD_AGENT_VOLUME_ONLY,
 } from './utils/env'
 import {client} from './utils/grpc'
 import {logger} from './utils/logger'
@@ -48,15 +49,18 @@ async function main() {
     process.exit(1)
   }
 
-  switch (CLOUD_AGENT_PROVIDER) {
-    case 'fly':
-      startStateStream(signal, FlyProvider)
-      break
-    case 'aws':
-      startStateStream(signal, AwsProvider)
-      break
-    default:
-      startStateStream(signal, AwsProvider)
+  // Volume only mode only handles ceph volume requests.
+  if (!CLOUD_AGENT_VOLUME_ONLY) {
+    switch (CLOUD_AGENT_PROVIDER) {
+      case 'fly':
+        startStateStream(signal, FlyProvider)
+        break
+      case 'aws':
+        startStateStream(signal, AwsProvider)
+        break
+      default:
+        startStateStream(signal, AwsProvider)
+    }
   }
 
   startUpdater(signal)

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -4,6 +4,7 @@ config()
 
 // CLOUD_AGENT_PROVIDER defines the cloud provider. It defaults to 'aws' but can be 'fly'.
 export const CLOUD_AGENT_PROVIDER = process.env.CLOUD_AGENT_PROVIDER ?? 'aws'
+export const CLOUD_AGENT_VOLUME_ONLY = process.env.CLOUD_AGENT_VOLUME_ONLY
 
 export const CLOUD_AGENT_API_URL = process.env.CLOUD_AGENT_API_URL ?? 'https://api.depot.dev'
 


### PR DESCRIPTION
With `CLOUD_AGENT_VOLUME_ONLY` only volumes and _not_ machines are reconciled.