### PR TITLE
feat: force delete all fly machines

### DIFF
--- a/src/utils/fly/reconcile.ts
+++ b/src/utils/fly/reconcile.ts
@@ -227,7 +227,8 @@ async function reconcileMachine(state: V1Machine[], machine: GetDesiredStateResp
         await stopAndWait(current)
       } catch {} // stop can sometime fail, ignore.
     }
-    const force = currentState === GetDesiredStateResponse_MachineState.ERROR
+    // Always force delete to handle the situations when machines cannot be deleted for some reason in the Fly API.
+    const force = true
     force ? console.log('Forcing delete of machine', current.id) : console.log('Deleting machine', current.id)
     await deleteMachine(current.id, force)
   }


### PR DESCRIPTION
Many times when we try to delete machines that are over-capacity we are not able to.
It turns out that the delete API call does not always work even when a machine is already stopped.

On Fly's advice we can force delete each time.