### PR TITLE
ci: restart fly cloud-agent weekly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-22.04
+    runs-on: depot-ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4.0.0
@@ -24,7 +24,7 @@ jobs:
 
   package:
     name: Package
-    runs-on: ubuntu-22.04
+    runs-on: depot-ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: depot/setup-action@v1

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   release-drafter:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@v6
         env:

--- a/.github/workflows/restart-cron.yml
+++ b/.github/workflows/restart-cron.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   restart-apps:
     name: Weekly fly cloud-agent restart
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
We found that the cloud-agent in EWR region was
not working for over a month.  Then yesterday
the cloud-agent in IAD stopped working as well.

Both were solved with an app restart.

This now automates restarting every Sunday at 2AM UTC 
to preventatively handle stuck fly machines.