### PR TITLE
Add depot metadata to Fly machines

### DIFF
--- a/proto/depot/cloud/v5/cloud.proto
+++ b/proto/depot/cloud/v5/cloud.proto
@@ -34,6 +34,8 @@ message GetDesiredStateResponse {
     optional string user_data = 7;
     optional FlyMachineOptions fly_options = 8;
     optional string zone = 9;
+    optional string project_id = 10;
+    optional string project_name = 11;
 
     message FlyMachineOptions {
       // Volume to attach to the machine.

--- a/src/proto/depot/cloud/v5/cloud_pb.ts
+++ b/src/proto/depot/cloud/v5/cloud_pb.ts
@@ -374,6 +374,16 @@ export class GetDesiredStateResponse_NewMachine extends Message<GetDesiredStateR
    */
   zone?: string
 
+  /**
+   * @generated from field: optional string project_id = 10;
+   */
+  projectId?: string
+
+  /**
+   * @generated from field: optional string project_name = 11;
+   */
+  projectName?: string
+
   constructor(data?: PartialMessage<GetDesiredStateResponse_NewMachine>) {
     super()
     proto3.util.initPartial(data, this)
@@ -391,6 +401,8 @@ export class GetDesiredStateResponse_NewMachine extends Message<GetDesiredStateR
     {no: 7, name: 'user_data', kind: 'scalar', T: 9 /* ScalarType.STRING */, opt: true},
     {no: 8, name: 'fly_options', kind: 'message', T: GetDesiredStateResponse_NewMachine_FlyMachineOptions, opt: true},
     {no: 9, name: 'zone', kind: 'scalar', T: 9 /* ScalarType.STRING */, opt: true},
+    {no: 10, name: 'project_id', kind: 'scalar', T: 9 /* ScalarType.STRING */, opt: true},
+    {no: 11, name: 'project_name', kind: 'scalar', T: 9 /* ScalarType.STRING */, opt: true},
   ])
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): GetDesiredStateResponse_NewMachine {

--- a/src/utils/fly/buildkit.ts
+++ b/src/utils/fly/buildkit.ts
@@ -10,10 +10,11 @@ export interface FlyBuildkitMachineRequest {
   image: string
   env: Record<string, string>
   files: Record<string, string>
+  metadata?: Record<string, string>
 }
 
 export async function launchBuildkitMachine(req: FlyBuildkitMachineRequest): Promise<V1Machine> {
-  const {cpu_kind, cpus, memGBs, depotID, region, volumeID, image, env, files} = req
+  const {cpu_kind, cpus, memGBs, depotID, region, volumeID, image, env, files, metadata} = req
   const machine = await launchMachine({
     name: depotID,
     region,
@@ -42,6 +43,7 @@ export async function launchBuildkitMachine(req: FlyBuildkitMachineRequest): Pro
       auto_destroy: false,
       restart: {policy: 'no'},
       dns: {},
+      metadata,
     },
   })
   return machine
@@ -50,7 +52,7 @@ export async function launchBuildkitMachine(req: FlyBuildkitMachineRequest): Pro
 const GPU_KIND = 'a10'
 
 export async function launchBuildkitGPUMachine(buildkit: FlyBuildkitMachineRequest): Promise<V1Machine> {
-  const {cpu_kind, cpus, memGBs, depotID, region, volumeID, image, env, files} = buildkit
+  const {cpu_kind, cpus, memGBs, depotID, region, volumeID, image, env, files, metadata} = buildkit
   if (region !== 'ord') {
     throw new Error('GPU machines are only available in the ord region')
   }
@@ -85,6 +87,7 @@ export async function launchBuildkitGPUMachine(buildkit: FlyBuildkitMachineReque
       auto_destroy: false,
       restart: {policy: 'no'},
       dns: {},
+      metadata,
     },
   })
   return machine

--- a/src/utils/fly/reconcile.ts
+++ b/src/utils/fly/reconcile.ts
@@ -184,6 +184,10 @@ async function reconcileNewMachine(
   console.log(`Launching new machine ${machine.id}`)
 
   const {cpuKind: cpu_kind, cpus, memGBs, needsGPU} = machineKind(machine.kind)
+  const metadata: Record<string, string> = {}
+  if (machine.projectId) metadata.depot_project_id = machine.projectId
+  if (machine.projectName) metadata.depot_project_name = machine.projectName
+
   let req = {
     cpu_kind,
     cpus,
@@ -198,6 +202,7 @@ async function reconcileNewMachine(
       DEPOT_CLOUD_MACHINE_ID: machine.id,
     },
     files: flyOptions.files,
+    metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
   }
 
   if (needsGPU) {


### PR DESCRIPTION
Summary
- add `project_id` and `project_name` fields to the desired-state machine proto so the controller can read them
- propagate depot metadata into `FlyBuildkitMachineRequest` and include it when launching both normal and GPU machines
- only attach metadata during reconciliation when values are provided

Testing
- Not run (not requested)